### PR TITLE
Implement password hashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/agentdemo/config/SecurityConfig.java
+++ b/src/main/java/com/example/agentdemo/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.example.agentdemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/agentdemo/entity/Account.java
+++ b/src/main/java/com/example/agentdemo/entity/Account.java
@@ -2,6 +2,7 @@ package com.example.agentdemo.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 @Data
@@ -17,6 +18,7 @@ public class Account {
     private String username;
 
     @Column(name = "password", nullable = false)
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
     @Column(name = "email", unique = true)

--- a/src/main/java/com/example/agentdemo/service/AccountService.java
+++ b/src/main/java/com/example/agentdemo/service/AccountService.java
@@ -4,6 +4,7 @@ import com.example.agentdemo.entity.Account;
 import com.example.agentdemo.repository.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import org.springframework.util.StringUtils;
@@ -13,6 +14,9 @@ public class AccountService {
 
     @Autowired
     private AccountRepository accountRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     public Account registerAccount(Account account) {
         if (!StringUtils.hasText(account.getUsername()) || !StringUtils.hasText(account.getPassword())) {
@@ -31,6 +35,7 @@ public class AccountService {
             throw new IllegalArgumentException("该手机号已被注册");
         }
 
+        account.setPassword(passwordEncoder.encode(account.getPassword()));
         account.setCreatedAt(LocalDateTime.now());
         return accountRepository.save(account);
     }


### PR DESCRIPTION
## Summary
- add security crypto dependency for password hashing
- add a configuration class to expose a `PasswordEncoder`
- hash passwords in `AccountService`
- mark `password` field as write-only in the `Account` entity

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_6842627004ec8332ae839fbe73c37943