### PR TITLE
Add validation and global exception handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
         <!-- Spring Data JPA -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/agentdemo/controller/AccountController.java
+++ b/src/main/java/com/example/agentdemo/controller/AccountController.java
@@ -3,6 +3,7 @@ package com.example.agentdemo.controller;
 import com.example.agentdemo.entity.Account;
 import com.example.agentdemo.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +17,7 @@ public class AccountController {
     private AccountService accountService;
 
     @PostMapping
-    public Account createAccount(@RequestBody Account account) {
+    public Account createAccount(@Valid @RequestBody Account account) {
         return accountService.registerAccount(account);
     }
 }

--- a/src/main/java/com/example/agentdemo/entity/Account.java
+++ b/src/main/java/com/example/agentdemo/entity/Account.java
@@ -1,6 +1,9 @@
 package com.example.agentdemo.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -14,16 +17,20 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank(message = "用户名不能为空")
     @Column(name = "username", nullable = false, unique = true, length = 50)
     private String username;
 
+    @NotBlank(message = "密码不能为空")
     @Column(name = "password", nullable = false)
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
+    @Email(message = "邮箱格式不正确")
     @Column(name = "email", unique = true)
     private String email;
 
+    @Pattern(regexp = "^\\+?\\d{10,15}$", message = "手机号格式不正确")
     @Column(name = "phone", unique = true)
     private String phone;
 

--- a/src/main/java/com/example/agentdemo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/agentdemo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.example.agentdemo.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("error", ex.getMessage());
+        return ResponseEntity.badRequest().body(errors);
+    }
+}


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-validation` dependency
- validate `Account` fields using annotations
- require `@Valid` in `AccountController`
- handle validation and `IllegalArgumentException` with `GlobalExceptionHandler`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6842639686f0833285644f5c9973b2f2