### PR TITLE
Enable CORS for local frontend

### DIFF
--- a/src/main/java/com/example/agentdemo/config/CorsConfig.java
+++ b/src/main/java/com/example/agentdemo/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.example.agentdemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- configure global CORS settings allowing requests from `http://localhost:3000`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684279eef0e08332a028f793f9a4478d