### PR TITLE
Implement basic login API

### DIFF
--- a/src/main/java/com/example/agentdemo/controller/AccountController.java
+++ b/src/main/java/com/example/agentdemo/controller/AccountController.java
@@ -1,6 +1,7 @@
 package com.example.agentdemo.controller;
 
 import com.example.agentdemo.entity.Account;
+import com.example.agentdemo.dto.LoginRequest;
 import com.example.agentdemo.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
 import jakarta.validation.Valid;
@@ -19,5 +20,10 @@ public class AccountController {
     @PostMapping
     public Account createAccount(@Valid @RequestBody Account account) {
         return accountService.registerAccount(account);
+    }
+
+    @PostMapping("/login")
+    public Account login(@Valid @RequestBody LoginRequest request) {
+        return accountService.login(request.getUsername(), request.getPassword());
     }
 }

--- a/src/main/java/com/example/agentdemo/dto/LoginRequest.java
+++ b/src/main/java/com/example/agentdemo/dto/LoginRequest.java
@@ -1,0 +1,27 @@
+package com.example.agentdemo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @NotBlank(message = "用户名不能为空")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/agentdemo/service/AccountService.java
+++ b/src/main/java/com/example/agentdemo/service/AccountService.java
@@ -39,4 +39,19 @@ public class AccountService {
         account.setCreatedAt(LocalDateTime.now());
         return accountRepository.save(account);
     }
+
+    public Account login(String username, String password) {
+        if (!StringUtils.hasText(username) || !StringUtils.hasText(password)) {
+            throw new IllegalArgumentException("用户名和密码不能为空");
+        }
+
+        Account account = accountRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("用户名或密码错误"));
+
+        if (!passwordEncoder.matches(password, account.getPassword())) {
+            throw new IllegalArgumentException("用户名或密码错误");
+        }
+
+        return account;
+    }
 }

--- a/src/test/java/com/example/agentdemo/controller/AccountControllerIntegrationTest.java
+++ b/src/test/java/com/example/agentdemo/controller/AccountControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,9 @@ class AccountControllerIntegrationTest {
 
     @Autowired
     private AccountRepository accountRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Test
     void createAccount_success() throws Exception {
@@ -47,6 +51,35 @@ class AccountControllerIntegrationTest {
 
         String json = "{\"username\":\"bob\",\"password\":\"another\"}";
         mockMvc.perform(post("/api/accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void login_success() throws Exception {
+        Account acc = new Account();
+        acc.setUsername("tom");
+        acc.setPassword(passwordEncoder.encode("secret"));
+        accountRepository.save(acc);
+
+        String json = "{\"username\":\"tom\",\"password\":\"secret\"}";
+        mockMvc.perform(post("/api/accounts/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("tom"));
+    }
+
+    @Test
+    void login_wrongPassword() throws Exception {
+        Account acc = new Account();
+        acc.setUsername("mary");
+        acc.setPassword(passwordEncoder.encode("pwd"));
+        accountRepository.save(acc);
+
+        String json = "{\"username\":\"mary\",\"password\":\"bad\"}";
+        mockMvc.perform(post("/api/accounts/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isInternalServerError());

--- a/src/test/java/com/example/agentdemo/service/AccountServiceTest.java
+++ b/src/test/java/com/example/agentdemo/service/AccountServiceTest.java
@@ -68,4 +68,22 @@ class AccountServiceTest {
         when(accountRepository.findByEmail("test@example.com")).thenReturn(Optional.of(new Account()));
         assertThrows(IllegalArgumentException.class, () -> accountService.registerAccount(account));
     }
+
+    @Test
+    void login_success() {
+        when(accountRepository.findByUsername("user1")).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches("rawpass", "rawpass")).thenReturn(true);
+
+        Account result = accountService.login("user1", "rawpass");
+
+        assertEquals(account, result);
+    }
+
+    @Test
+    void login_wrong_password() {
+        when(accountRepository.findByUsername("user1")).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches("wrong", "rawpass")).thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> accountService.login("user1", "wrong"));
+    }
 }


### PR DESCRIPTION
## Summary
- add LoginRequest DTO
- implement login logic in service
- expose `/api/accounts/login` endpoint
- add unit and integration tests for login

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427e4e0ab88332bb1cc531d4dcd4e5