### PR TITLE
Add OpenAI API integration

### DIFF
--- a/src/main/java/com/example/agentdemo/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/agentdemo/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.example.agentdemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/agentdemo/controller/OpenAiController.java
+++ b/src/main/java/com/example/agentdemo/controller/OpenAiController.java
@@ -1,0 +1,25 @@
+package com.example.agentdemo.controller;
+
+import com.example.agentdemo.dto.ChatRequest;
+import com.example.agentdemo.dto.ChatResponse;
+import com.example.agentdemo.service.OpenAiService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/openai")
+public class OpenAiController {
+
+    @Autowired
+    private OpenAiService openAiService;
+
+    @PostMapping("/chat")
+    public ChatResponse chat(@Valid @RequestBody ChatRequest request) {
+        String answer = openAiService.chat(request.getMessage());
+        return new ChatResponse(answer);
+    }
+}

--- a/src/main/java/com/example/agentdemo/dto/ChatRequest.java
+++ b/src/main/java/com/example/agentdemo/dto/ChatRequest.java
@@ -1,0 +1,16 @@
+package com.example.agentdemo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ChatRequest {
+    @NotBlank(message = "消息不能为空")
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/agentdemo/dto/ChatResponse.java
+++ b/src/main/java/com/example/agentdemo/dto/ChatResponse.java
@@ -1,0 +1,17 @@
+package com.example.agentdemo.dto;
+
+public class ChatResponse {
+    private String answer;
+
+    public ChatResponse(String answer) {
+        this.answer = answer;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/example/agentdemo/service/OpenAiService.java
+++ b/src/main/java/com/example/agentdemo/service/OpenAiService.java
@@ -1,0 +1,59 @@
+package com.example.agentdemo.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OpenAiService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Value("${openai.api.url:https://api.openai.com/v1/chat/completions}")
+    private String apiUrl;
+
+    @Value("${openai.model:gpt-3.5-turbo}")
+    private String model;
+
+    public OpenAiService(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public String chat(String message) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            Map<String, Object> request = new HashMap<>();
+            request.put("model", model);
+            request.put("messages", Collections.singletonList(
+                    Collections.singletonMap("role", "user")
+            ));
+            ((java.util.List<Map<String, String>>) request.get("messages")).get(0).put("content", message);
+
+            HttpEntity<String> entity = new HttpEntity<>(objectMapper.writeValueAsString(request), headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(apiUrl, entity, String.class);
+
+            JsonNode node = objectMapper.readTree(response.getBody());
+            return node.path("choices").get(0).path("message").path("content").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to call OpenAI API", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,9 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
+
+# OpenAI API configuration
+openai.api.key=YOUR_API_KEY
+openai.api.url=https://api.openai.com/v1/chat/completions
+openai.model=gpt-3.5-turbo
+

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,3 +4,6 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+
+openai.api.key=TEST_KEY
+


### PR DESCRIPTION
## Summary
- introduce `OpenAiService` for calling OpenAI chat API
- expose new `/api/openai/chat` REST endpoint
- add request/response DTOs
- configure `RestTemplate` bean
- add OpenAI API properties for main and test profiles

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428308a7c88332af0f1ceea02db0c7