### PR TITLE
Load credentials from environment

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=agentDemo
 spring.datasource.url=jdbc:mysql://localhost:3306/agent_demo?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=mysqlchx5566
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA ??????
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 
 # OpenAI API configuration
-openai.api.key=YOUR_API_KEY
+openai.api.key=${OPENAI_API_KEY}
 openai.api.url=https://api.openai.com/v1/chat/completions
 openai.model=gpt-3.5-turbo
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -5,5 +5,5 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 
-openai.api.key=TEST_KEY
+openai.api.key=${OPENAI_API_KEY:TEST_KEY}
 


### PR DESCRIPTION
## Summary
- read DB password and OpenAI API key from environment variables
- allow tests to supply OPENAI_API_KEY via env with default

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_684285bddf248332918148aa1c237b18